### PR TITLE
Add IPv6 support

### DIFF
--- a/arubacloud.go
+++ b/arubacloud.go
@@ -32,6 +32,7 @@ type Driver struct {
 	Username      string
 	Password      string
 	Endpoint      string
+	ConfigureIPv6 bool
 
 	// internal ids
 	ServerId      int
@@ -109,7 +110,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage: "Absolute path of the ssh private key",
 			Value: "",
 		},
-		
+		mcnflag.BoolFlag{
+			EnvVar: "AC_IPV6",
+			Name: "ac_ipv6",
+			Usage: "Configure an IPv6 address for the ArubaCloud VM",
+		},
 	}
 }
 
@@ -147,8 +152,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHKey = flags.String("ac_ssh_key")
 	d.Action = flags.String("ac_action")
 	d.IPAddress = flags.String("ac_ip")
-	
 	d.SSHUser = "root"
+	d.ConfigureIPv6 = flags.Bool("ac_ipv6")
 
 	return nil
 }
@@ -213,6 +218,7 @@ func (d *Driver) CreateSmart() error {
 		cloudpackage.PackageID,
 		template.Id,
 		key,
+		d.ConfigureIPv6,
 	)
 
 	if err != nil {
@@ -356,6 +362,7 @@ func (d *Driver) CreatePro() error {
 		diskSize,
 		cpuQuantity,
 		ramQuantity,
+		d.ConfigureIPv6,
 	)
 
 	if err != nil {

--- a/arubacloud_test.go
+++ b/arubacloud_test.go
@@ -16,6 +16,7 @@ func TestConfigFlags(t *testing.T) {
 			"ac_endpoint": "dc1",
 			"ac_template": "ubuntu_xx_x",
 			"ac_size": "Large",
+			"ac_ipv6": "true",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}	
@@ -35,6 +36,7 @@ func TestDefaultConfigFlags(t *testing.T) {
 			"ac_username": "ARU-xxxx",
 			"ac_password": "xxxx",
 			"ac_admin_password": "xxxx",
+			"ac_ipv6": "true",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}	


### PR DESCRIPTION
Added IPv6 support for virtual machine creation (both PRO and SMART), must go live after https://github.com/Arubacloud/goarubacloud/pull/5.